### PR TITLE
small bugfix regarding saving the step

### DIFF
--- a/rin_pytorch/rin_pytorch.py
+++ b/rin_pytorch/rin_pytorch.py
@@ -870,7 +870,7 @@ class Trainer(object):
             return
 
         data = {
-            'step': self.step,
+            'step': self.step + 1,
             'model': self.accelerator.get_state_dict(self.model),
             'opt': self.opt.state_dict(),
             'ema': self.ema.state_dict(),


### PR DESCRIPTION
Hey there,

big fan of your work!

I played a bit around with it, and found that saving and loading a state executes the last step again.
For example step=1000, it will load with step=1000, execute the step again and save the model directly after that step. (`save_and_sample_every` will be ignored in that case)

To resolve this, the step needs to be incremented earlier in the training loop or, when saving, the step written should be incremented.