### PR TITLE
Fix has_int_squareroot

### DIFF
--- a/rin_pytorch/rin_pytorch.py
+++ b/rin_pytorch/rin_pytorch.py
@@ -49,7 +49,8 @@ def cycle(dl):
             yield data
 
 def has_int_squareroot(num):
-    return (math.sqrt(num) ** 2) == num
+    num_sqrt = math.sqrt(num)
+    return int(num_sqrt) == num_sqrt
 
 def num_to_groups(num, divisor):
     groups = num // divisor


### PR DESCRIPTION
First of all, thank you for providing this very clean implementation!

Looking over the code, i found this tiny bug in the `has_int_squareroot` helper function:
https://github.com/lucidrains/recurrent-interface-network-pytorch/blob/8cc1db6acce2be48c60420c0bdd52a2348402cf6/rin_pytorch/rin_pytorch.py#L51-L52

For e.g. `11, 14, 17, 21, 22, 27, ...` it would return true, even though it should return false.

This PR fixes the issue.