### PR TITLE
Fix Accelerate Multiprocessing Issues: Model Training/Saving/Loading

### DIFF
--- a/rin_pytorch/rin_pytorch.py
+++ b/rin_pytorch/rin_pytorch.py
@@ -1004,12 +1004,12 @@ class Trainer(object):
                 for _ in range(self.gradient_accumulate_every):
                     data = next(self.dl).to(device)
 
-                    with self.accelerator.autocast():
+                    with accelerator.autocast():
                         loss = self.model(data)
                         loss = loss / self.gradient_accumulate_every
                         total_loss += loss.item()
 
-                    self.accelerator.backward(loss)
+                    accelerator.backward(loss)
 
                 pbar.set_description(f'loss: {total_loss:.4f}')
 

--- a/rin_pytorch/rin_pytorch.py
+++ b/rin_pytorch/rin_pytorch.py
@@ -22,7 +22,7 @@ from PIL import Image
 from tqdm.auto import tqdm
 from ema_pytorch import EMA
 
-from accelerate import Accelerator
+from accelerate import Accelerator, DistributedDataParallelKwargs
 
 # helpers functions
 
@@ -913,7 +913,8 @@ class Trainer(object):
 
         self.accelerator = Accelerator(
             split_batches = split_batches,
-            mixed_precision = 'fp16' if fp16 else 'no'
+            mixed_precision = 'fp16' if fp16 else 'no',
+            kwargs_handlers = [DistributedDataParallelKwargs(find_unused_parameters=True)]
         )
 
         self.accelerator.native_amp = amp

--- a/rin_pytorch/rin_pytorch.py
+++ b/rin_pytorch/rin_pytorch.py
@@ -944,11 +944,14 @@ class Trainer(object):
 
         # for logging results in a folder periodically
 
+        self.results_folder = Path(results_folder)
+
+        if self.accelerator.is_local_main_process:
+            self.results_folder.mkdir(exist_ok = True)
+
         if self.accelerator.is_main_process:
             self.ema = EMA(diffusion_model, beta = ema_decay, update_every = ema_update_every)
 
-            self.results_folder = Path(results_folder)
-            self.results_folder.mkdir(exist_ok = True)
 
         # step counter state
 
@@ -980,7 +983,9 @@ class Trainer(object):
 
         self.step = data['step']
         self.opt.load_state_dict(data['opt'])
-        self.ema.load_state_dict(data['ema'])
+
+        if self.accelerator.is_main_process:
+            self.ema.load_state_dict(data['ema'])
 
         if exists(self.accelerator.scaler) and exists(data['scaler']):
             self.accelerator.scaler.load_state_dict(data['scaler'])
@@ -1014,20 +1019,27 @@ class Trainer(object):
 
                 accelerator.wait_for_everyone()
 
-                if accelerator.is_main_process:
-                    self.ema.to(device)
-                    self.ema.update()
+                # save milestone on every local main process, sample only on global main process
 
-                    if self.step != 0 and self.step % self.save_and_sample_every == 0:
-                        self.ema.ema_model.eval()
+                if accelerator.is_local_main_process:
+                    milestone = self.step // self.save_and_sample_every
+                    save_and_sample = self.step != 0 and self.step % self.save_and_sample_every == 0
+                    
+                    if accelerator.is_main_process:
+                        self.ema.to(device)
+                        self.ema.update()
 
-                        with torch.no_grad():
-                            milestone = self.step // self.save_and_sample_every
-                            batches = num_to_groups(self.num_samples, self.batch_size)
-                            all_images_list = list(map(lambda n: self.ema.ema_model.sample(batch_size=n), batches))
+                        if save_and_sample:
+                            self.ema.ema_model.eval()
 
-                        all_images = torch.cat(all_images_list, dim = 0)
-                        utils.save_image(all_images, str(self.results_folder / f'sample-{milestone}.png'), nrow = int(math.sqrt(self.num_samples)))
+                            with torch.no_grad():
+                                batches = num_to_groups(self.num_samples, self.batch_size)
+                                all_images_list = list(map(lambda n: self.ema.ema_model.sample(batch_size=n), batches))
+
+                            all_images = torch.cat(all_images_list, dim = 0)
+                            utils.save_image(all_images, str(self.results_folder / f'sample-{milestone}.png'), nrow = int(math.sqrt(self.num_samples)))
+
+                    if save_and_sample:
                         self.save(milestone)
 
                 self.step += 1


### PR DESCRIPTION
This PR fixes some issues I encountered when using this code with multiple GPUs (1 node, 2 GPUs, 🤗 Accelerate 0.21.0)

### Model Saving/Loading
There where some logic issues during checkpoint saving and loading depending on process type (local main, global main).
This fix makes sure that:
 - all processes can load checkpoints
 - all local main processes (`accelerator.is_local_main_process`) save the checkpoints (so that it is available on all machines) _(could cause issues if a shared filesystem is used)_
 - only the global main process (`accelerator.is_main_process`) maintains an EMA model and does the sampling

### Fix DDP exception during training

During training, I got the following exception, which could be fixed by passing `find_unused_parameters=True` to DistributedDataParallel ([accelerate#648](https://github.com/huggingface/accelerate/issues/648))
```
RuntimeError: Expected to have finished reduction in the prior iteration before starting a new one.
This error indicates that your module has parameters that were not used in producing loss.
You can enable unused parameter detection by passing the keyword argument `find_unused_parameters=True`
to `torch.nn.parallel.DistributedDataParallel`, and by
making sure all `forward` function outputs participate in calculating loss.
```